### PR TITLE
v4.0: Add Custom game mode with adjustable settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,12 +83,17 @@ Game state is managed through module-level variables:
 
 **Game Mechanics:**
 - Score: 1 point per food collected
-- **Separate high scores** saved for each difficulty level
-- Four difficulty levels with dynamic canvas sizing (40px tiles):
+- **Separate high scores** saved for each difficulty level (including custom mode)
+- Five difficulty levels with dynamic canvas sizing (40px tiles):
   - Easy: 10x10 tiles, 150ms speed
   - Medium: 15x15 tiles, 100ms speed
   - Hard: 20x20 tiles, 60ms speed
   - **EXTREME**: 25x25 tiles, 30ms speed (extremely fast and challenging)
+  - **Custom**: Fully customizable (10-30 tiles, 20-200ms speed)
+- **Custom Mode**: Adjustable sliders for map size and snake speed
+  - Map size: 10-30 tiles (10x10 to 30x30 grid)
+  - Speed: 20ms (fastest) to 200ms (slowest)
+  - Separate high score tracking for custom mode
 - Toggleable wall collision mode (game over vs. wrap-around)
 - Pause/resume functionality (Space key or button)
 - Keyboard controls: WASD and Arrow keys
@@ -186,7 +191,7 @@ Game state is managed through module-level variables:
 - All changes maintain the GRID_SIZE ratio (40px per tile)
 
 ### Version
-Current version: **v3.2**
+Current version: **v4.0**
 - Displayed in top-right corner of the UI
 - **Version Format**: `vMAJOR.MINOR`
   - **Major (first number)**: Incremented for new features or major updates
@@ -195,6 +200,7 @@ Current version: **v3.2**
 - Update this in both `index.html` and this documentation when releasing new versions
 
 **Version History:**
+- **v4.0**: Added Custom game mode with adjustable map size (10-30 tiles) and speed (20-200ms)
 - **v3.2**: Snake waits for first player input before moving (keyboard and mobile D-pad support)
 - **v3.1**: Added 1-second delay before snake starts moving, difficulty-specific high score labels
 - **v3.0**: Increased tile size to 40px (larger tiles with 400-1000px canvases), per-difficulty high score tracking, added EXTREME difficulty mode

--- a/game.js
+++ b/game.js
@@ -15,6 +15,7 @@ const overlayMessage = document.getElementById('overlayMessage');
 
 // Screen elements
 const startScreen = document.getElementById('startScreen');
+const customScreen = document.getElementById('customScreen');
 const gameHeader = document.querySelector('.game-header');
 const controlsPanel = document.querySelector('.controls-panel');
 const gameContent = document.querySelector('.game-content');
@@ -34,6 +35,15 @@ const eraseHighscoreBtn = document.getElementById('eraseHighscoreBtn');
 // Mobile controls
 const mobileControls = document.getElementById('mobileControls');
 const dpadButtons = document.querySelectorAll('.dpad-btn');
+
+// Custom mode elements
+const customSizeSlider = document.getElementById('customSize');
+const customSpeedSlider = document.getElementById('customSpeed');
+const customSizeValue = document.getElementById('customSizeValue');
+const customSizeValue2 = document.getElementById('customSizeValue2');
+const customSpeedValue = document.getElementById('customSpeedValue');
+const startCustomBtn = document.getElementById('startCustomBtn');
+const backToMenuBtn = document.getElementById('backToMenuBtn');
 
 // Difficulty settings (speed in ms, tile count, and grid size)
 const DIFFICULTY_SETTINGS = {
@@ -75,14 +85,24 @@ function saveHighScore(difficulty, score) {
 // Screen management
 function showStartScreen() {
     startScreen.classList.remove('hidden');
+    customScreen.classList.add('hidden');
     gameHeader.classList.add('hidden');
     controlsPanel.classList.add('hidden');
     gameContent.classList.add('hidden');
     if (gameLoop) clearInterval(gameLoop);
 }
 
+function showCustomScreen() {
+    startScreen.classList.add('hidden');
+    customScreen.classList.remove('hidden');
+    gameHeader.classList.add('hidden');
+    controlsPanel.classList.add('hidden');
+    gameContent.classList.add('hidden');
+}
+
 function showGameScreen() {
     startScreen.classList.add('hidden');
+    customScreen.classList.add('hidden');
     gameHeader.classList.remove('hidden');
     controlsPanel.classList.remove('hidden');
     gameContent.classList.remove('hidden');
@@ -108,6 +128,32 @@ function startGameWithDifficulty(difficulty) {
 
     // Load high score for this difficulty
     highScore = getHighScore(difficulty);
+    updateScore();
+
+    // Show game screen and start game
+    showGameScreen();
+    initGame();
+}
+
+function startCustomGame(tiles, speed) {
+    currentDifficulty = 'custom';
+    baseSpeed = speed;
+    currentSpeed = baseSpeed;
+
+    // Apply speed multiplier for mobile/tablet modes (40% slower)
+    if (document.body.classList.contains('mobile-mode') ||
+        document.body.classList.contains('tablet-mode')) {
+        currentSpeed = Math.floor(currentSpeed * 1.4);
+    }
+
+    // Update grid size and canvas dimensions
+    GRID_SIZE = 40;
+    TILE_COUNT = tiles;
+    canvas.width = tiles * 40;
+    canvas.height = tiles * 40;
+
+    // Load high score for custom mode
+    highScore = getHighScore('custom');
     updateScore();
 
     // Show game screen and start game
@@ -729,6 +775,7 @@ eraseHighscoreBtn.addEventListener('click', () => {
         localStorage.removeItem('snakeHighScore_medium');
         localStorage.removeItem('snakeHighScore_hard');
         localStorage.removeItem('snakeHighScore_extreme');
+        localStorage.removeItem('snakeHighScore_custom');
         highScore = 0;
         highScoreElement.textContent = highScore;
         alert('All high scores have been erased!');
@@ -794,7 +841,11 @@ if (savedControlMode === 'mobile') {
 document.querySelectorAll('.difficulty-btn').forEach(btn => {
     btn.addEventListener('click', () => {
         const difficulty = btn.dataset.difficulty;
-        startGameWithDifficulty(difficulty);
+        if (difficulty === 'custom') {
+            showCustomScreen();
+        } else {
+            startGameWithDifficulty(difficulty);
+        }
     });
 });
 
@@ -804,6 +855,30 @@ homeBtn.addEventListener('click', () => {
     overlay.classList.add('hidden');
     isPaused = false;
     isGameOver = false;
+});
+
+// Custom mode slider updates
+customSizeSlider.addEventListener('input', (e) => {
+    const value = e.target.value;
+    customSizeValue.textContent = value;
+    customSizeValue2.textContent = value;
+});
+
+customSpeedSlider.addEventListener('input', (e) => {
+    const value = e.target.value;
+    customSpeedValue.textContent = value;
+});
+
+// Start custom game
+startCustomBtn.addEventListener('click', () => {
+    const tiles = parseInt(customSizeSlider.value);
+    const speed = parseInt(customSpeedSlider.value);
+    startCustomGame(tiles, speed);
+});
+
+// Back to menu button
+backToMenuBtn.addEventListener('click', () => {
+    showStartScreen();
 });
 
 // Fullscreen toggle

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <button id="fullscreenBtn" class="fullscreen-btn" title="Fullscreen">⛶</button>
-        <span class="version-number">v3.2</span>
+        <span class="version-number">v4.0</span>
         <button id="settingsBtn" class="settings-btn" title="Settings">⚙️</button>
 
         <!-- Start Screen -->
@@ -33,6 +33,32 @@
                     <span class="difficulty-name">EXTREME</span>
                     <span class="difficulty-desc">25x25 Tiles • Lightning Fast</span>
                 </button>
+                <button class="difficulty-btn custom-btn" data-difficulty="custom">
+                    <span class="difficulty-name">Custom</span>
+                    <span class="difficulty-desc">Customize Size & Speed</span>
+                </button>
+            </div>
+        </div>
+
+        <!-- Custom Settings Screen -->
+        <div id="customScreen" class="custom-screen hidden">
+            <h1 class="custom-title">Custom Game</h1>
+            <p class="custom-subtitle">Customize Your Experience</p>
+            <div class="custom-controls">
+                <div class="custom-control-group">
+                    <label for="customSize">Map Size: <span id="customSizeValue">15</span>x<span id="customSizeValue2">15</span></label>
+                    <input type="range" id="customSize" min="10" max="30" value="15" step="1">
+                    <span class="custom-hint">10-30 tiles</span>
+                </div>
+                <div class="custom-control-group">
+                    <label for="customSpeed">Speed: <span id="customSpeedValue">100</span>ms</label>
+                    <input type="range" id="customSpeed" min="20" max="200" value="100" step="10">
+                    <span class="custom-hint">20ms (fastest) - 200ms (slowest)</span>
+                </div>
+                <div class="custom-buttons">
+                    <button id="startCustomBtn" class="btn-primary">Start Game</button>
+                    <button id="backToMenuBtn" class="btn-secondary">Back</button>
+                </div>
             </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -203,6 +203,139 @@ body.light-mode .fullscreen-btn {
     50% { transform: translateY(-3px) scale(1.02); }
 }
 
+.custom-btn {
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    color: white;
+    box-shadow: 0 4px 15px rgba(245, 158, 11, 0.4);
+    border: 2px solid #fbbf24;
+}
+
+.custom-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 25px rgba(245, 158, 11, 0.6);
+    border-color: #fcd34d;
+}
+
+/* Custom Settings Screen */
+.custom-screen {
+    text-align: center;
+    padding: 40px 20px;
+}
+
+.custom-screen.hidden {
+    display: none;
+}
+
+.custom-title {
+    font-size: 3em;
+    color: #f59e0b;
+    margin-bottom: 10px;
+    text-shadow: 0 0 20px rgba(245, 158, 11, 0.5);
+}
+
+.custom-subtitle {
+    font-size: 1.2em;
+    color: rgba(255, 255, 255, 0.7);
+    margin-bottom: 40px;
+}
+
+.custom-controls {
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.custom-control-group {
+    margin-bottom: 30px;
+    text-align: left;
+}
+
+.custom-control-group label {
+    display: block;
+    font-size: 1.2em;
+    color: white;
+    margin-bottom: 10px;
+    font-weight: 600;
+}
+
+.custom-control-group label span {
+    color: #f59e0b;
+}
+
+.custom-control-group input[type="range"] {
+    width: 100%;
+    height: 8px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 5px;
+    outline: none;
+    margin-bottom: 5px;
+    cursor: pointer;
+}
+
+.custom-control-group input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    border-radius: 50%;
+    cursor: pointer;
+    box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+}
+
+.custom-control-group input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    border-radius: 50%;
+    cursor: pointer;
+    border: none;
+    box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+}
+
+.custom-hint {
+    font-size: 0.9em;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.custom-buttons {
+    display: flex;
+    gap: 15px;
+    margin-top: 40px;
+}
+
+.btn-primary, .btn-secondary {
+    flex: 1;
+    padding: 15px 30px;
+    font-size: 1.1em;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    font-weight: 600;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    color: white;
+    box-shadow: 0 4px 15px rgba(245, 158, 11, 0.4);
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(245, 158, 11, 0.6);
+}
+
+.btn-secondary {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+    border: 2px solid rgba(255, 255, 255, 0.2);
+}
+
+.btn-secondary:hover {
+    background: rgba(255, 255, 255, 0.15);
+    transform: translateY(-2px);
+}
+
 .game-header {
     text-align: center;
     margin-bottom: 20px;


### PR DESCRIPTION
- Add Custom difficulty button with orange gradient styling
- Create custom settings screen with sliders for map size and speed
- Map size slider: 10-30 tiles (adjustable grid size)
- Speed slider: 20-200ms (from fastest to slowest)
- Real-time slider value updates displayed in labels
- Custom mode has its own high score tracking (snakeHighScore_custom)
- Back button to return to main menu from custom screen
- Add startCustomGame() function for custom parameters
- Update showStartScreen/showGameScreen to handle custom screen
- Update erase high score to include custom mode
- Update version to v4.0 in index.html
- Update CLAUDE.md with v4.0 version history and custom mode documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)