### PR TITLE
v5.5: Add mobile control improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Game state is managed through module-level variables:
 
 ### Version
 
-**Snake Game Version:** **v5.5.0**
+**Snake Game Version:** **v5.5.1**
 - Displayed in top-right corner of the Snake game (in snake.html)
 - Tracks changes specific to the Snake game
 
@@ -214,6 +214,7 @@ Game state is managed through module-level variables:
 - Update version numbers in the respective HTML files and this documentation when releasing new versions
 
 **Snake Game Version History:**
+- **v5.5.1**: Fixed mobile viewport cutoff issues where content at top and bottom of screen was cut off. Removed `position: fixed` from body and changed `overflow: hidden` to `overflow: auto` on html/body to allow proper scrolling on mobile devices. Changed mobile-mode container from `max-height: 100vh` with `overflow-y: auto` to `max-height: none` with `overflow-y: visible` for better mobile compatibility.
 - **v5.5.0**: Added joystick control and swipe-to-turn options for mobile/tablet modes. New "Touch Control Type" setting in settings modal allows users to switch between three control modes: D-Pad (default), Joystick (analog stick control), and Swipe (gesture-only with no visual controls). Joystick features direction change detection to prevent input flooding. Swipe detection targets canvas element for better gesture recognition across the game area. Control type preference persists via localStorage (`snakeMobileControlType`). The setting is only visible when in mobile or tablet mode.
 - **v5.3.4**: Fixed critical bug where pressing LEFT as first move caused instant death. The validation logic was incorrectly allowing opposite moves on first input. Added implicit starting direction (RIGHT) validation, and removed the `!isFirstInput` check from all direction validations so opposite moves are blocked regardless of timing. This ensures the snake's body layout (extending left) is respected when validating the first player input.
 - **v5.3.3**: Improved Hell Mode visuals - changed from circular conic-gradient border to left-to-right linear-gradient fill animation. Added automatic progress decay (resets after 2 seconds of inactivity). Progress resets when closing settings modal via X button or clicking outside (unless Hell mode is already active).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Game state is managed through module-level variables:
 
 ### Version
 
-**Snake Game Version:** **v5.3.4**
+**Snake Game Version:** **v5.5.0**
 - Displayed in top-right corner of the Snake game (in snake.html)
 - Tracks changes specific to the Snake game
 
@@ -214,6 +214,7 @@ Game state is managed through module-level variables:
 - Update version numbers in the respective HTML files and this documentation when releasing new versions
 
 **Snake Game Version History:**
+- **v5.5.0**: Added joystick control and swipe-to-turn options for mobile/tablet modes. New "Touch Control Type" setting in settings modal allows users to switch between three control modes: D-Pad (default), Joystick (analog stick control), and Swipe (gesture-only with no visual controls). Joystick features direction change detection to prevent input flooding. Swipe detection targets canvas element for better gesture recognition across the game area. Control type preference persists via localStorage (`snakeMobileControlType`). The setting is only visible when in mobile or tablet mode.
 - **v5.3.4**: Fixed critical bug where pressing LEFT as first move caused instant death. The validation logic was incorrectly allowing opposite moves on first input. Added implicit starting direction (RIGHT) validation, and removed the `!isFirstInput` check from all direction validations so opposite moves are blocked regardless of timing. This ensures the snake's body layout (extending left) is respected when validating the first player input.
 - **v5.3.3**: Improved Hell Mode visuals - changed from circular conic-gradient border to left-to-right linear-gradient fill animation. Added automatic progress decay (resets after 2 seconds of inactivity). Progress resets when closing settings modal via X button or clicking outside (unless Hell mode is already active).
 - **v5.3.2**: Fixed critical bug where pressing the opposite direction to the snake's current movement caused instant death. This affected both normal mode and Hell mode. The validation logic now properly checks if the new direction is opposite to the reference direction (current or queued) and prevents such moves.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Works in all modern browsers that support:
 
 ## Version
 
-### Snake Game Version: **v5.3.4**
+### Snake Game Version: **v5.5.0**
 
 #### Recent Updates
+- **v5.5.0**: Added joystick control and swipe-to-turn options for mobile/tablet modes. New "Touch Control Type" setting allows switching between D-Pad, Joystick, and Swipe-only controls. Control preference persists via localStorage.
 - **v5.3.4**: Fixed critical bug where pressing LEFT as first move caused instant death. Snake now properly recognizes its implicit starting direction (RIGHT), and opposite direction blocking works correctly for first input.
 - **v5.3.3**: Improved Hell Mode visuals - changed from circular border to left-to-right fill animation. Added automatic progress decay (resets after 2 seconds of inactivity). Progress resets when closing settings modal (unless Hell mode is active).
 - **v5.3.2**: Fixed critical bug where pressing the opposite direction to snake movement caused instant death (in both normal and Hell mode)

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Works in all modern browsers that support:
 
 ## Version
 
-### Snake Game Version: **v5.5.0**
+### Snake Game Version: **v5.5.1**
 
 #### Recent Updates
+- **v5.5.1**: Fixed mobile viewport cutoff issues at top and bottom of screen. Improved mobile scrolling behavior by removing fixed positioning.
 - **v5.5.0**: Added joystick control and swipe-to-turn options for mobile/tablet modes. New "Touch Control Type" setting allows switching between D-Pad, Joystick, and Swipe-only controls. Control preference persists via localStorage.
 - **v5.3.4**: Fixed critical bug where pressing LEFT as first move caused instant death. Snake now properly recognizes its implicit starting direction (RIGHT), and opposite direction blocking works correctly for first input.
 - **v5.3.3**: Improved Hell Mode visuals - changed from circular border to left-to-right fill animation. Added automatic progress decay (resets after 2 seconds of inactivity). Progress resets when closing settings modal (unless Hell mode is active).

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 <div class="game-icon">🐍</div>
                 <h2 class="game-name">Snake Game</h2>
                 <p class="game-description">Classic arcade snake with multiple difficulty levels and custom mode</p>
-                <span class="game-version">v5.3.4</span>
+                <span class="game-version">v5.5.0</span>
             </a>
 
             <!-- Placeholder for future games -->

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 <div class="game-icon">🐍</div>
                 <h2 class="game-name">Snake Game</h2>
                 <p class="game-description">Classic arcade snake with multiple difficulty levels and custom mode</p>
-                <span class="game-version">v5.5.0</span>
+                <span class="game-version">v5.5.1</span>
             </a>
 
             <!-- Placeholder for future games -->

--- a/snake.html
+++ b/snake.html
@@ -14,7 +14,7 @@
             <span class="material-symbols-outlined">home</span>
         </a>
         <button id="fullscreenBtn" class="fullscreen-btn" title="Fullscreen">⛶</button>
-        <span class="version-number" id="versionNumber" title="View Changelog">v5.3.4</span>
+        <span class="version-number" id="versionNumber" title="View Changelog">v5.5.0</span>
         <button id="settingsBtn" class="settings-btn" title="Settings">
             <span class="material-symbols-outlined">settings</span>
         </button>
@@ -25,6 +25,15 @@
                 <span class="close-btn" id="closeChangelog">&times;</span>
                 <h2>Version History</h2>
                 <div class="changelog-list">
+                    <div class="changelog-item">
+                        <h3>v5.5.0</h3>
+                        <ul>
+                            <li>Added joystick control option for mobile and tablet modes</li>
+                            <li>Added swipe-to-turn functionality for touch devices</li>
+                            <li>Added "Touch Control Type" setting with three options: D-Pad, Joystick, and Swipe</li>
+                            <li>Control type preference persists via localStorage</li>
+                        </ul>
+                    </div>
                     <div class="changelog-item">
                         <h3>v5.3.4</h3>
                         <ul>
@@ -302,6 +311,7 @@
 
             <!-- Mobile Touch Controls -->
             <div id="mobileControls" class="mobile-controls hidden">
+                <!-- D-pad controls -->
                 <div class="dpad-container">
                     <button class="dpad-btn dpad-up" data-direction="up">▲</button>
                     <div class="dpad-middle">
@@ -310,6 +320,13 @@
                         <button class="dpad-btn dpad-right" data-direction="right">▶</button>
                     </div>
                     <button class="dpad-btn dpad-down" data-direction="down">▼</button>
+                </div>
+
+                <!-- Joystick controls -->
+                <div class="joystick-container hidden">
+                    <div class="joystick-base">
+                        <div class="joystick-stick"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -336,6 +353,14 @@
                         <button id="pcModeBtn" class="toggle-btn active">🖥️ PC</button>
                         <button id="mobileModeBtn" class="toggle-btn">📱 Mobile</button>
                         <button id="tabletModeBtn" class="toggle-btn">📲 Tablet</button>
+                    </div>
+                </div>
+                <div class="setting-item mobile-tablet-only hidden" id="mobileControlTypeSetting">
+                    <label for="mobileControlTypeToggle">Touch Control Type:</label>
+                    <div class="toggle-group">
+                        <button id="dpadControlBtn" class="toggle-btn active">D-Pad</button>
+                        <button id="joystickControlBtn" class="toggle-btn">Joystick</button>
+                        <button id="swipeControlBtn" class="toggle-btn">Swipe</button>
                     </div>
                 </div>
                 <div class="setting-item mobile-tablet-only hidden" id="mobileSlowdownSetting">

--- a/snake.html
+++ b/snake.html
@@ -14,7 +14,7 @@
             <span class="material-symbols-outlined">home</span>
         </a>
         <button id="fullscreenBtn" class="fullscreen-btn" title="Fullscreen">⛶</button>
-        <span class="version-number" id="versionNumber" title="View Changelog">v5.5.0</span>
+        <span class="version-number" id="versionNumber" title="View Changelog">v5.5.1</span>
         <button id="settingsBtn" class="settings-btn" title="Settings">
             <span class="material-symbols-outlined">settings</span>
         </button>
@@ -25,6 +25,13 @@
                 <span class="close-btn" id="closeChangelog">&times;</span>
                 <h2>Version History</h2>
                 <div class="changelog-list">
+                    <div class="changelog-item">
+                        <h3>v5.5.1</h3>
+                        <ul>
+                            <li>Fixed mobile viewport cutoff issues at top and bottom of screen</li>
+                            <li>Improved mobile scrolling behavior</li>
+                        </ul>
+                    </div>
                     <div class="changelog-item">
                         <h3>v5.5.0</h3>
                         <ul>

--- a/style.css
+++ b/style.css
@@ -696,6 +696,10 @@ body.light-mode .settings-btn .material-symbols-outlined {
     align-items: center;
 }
 
+.dpad-container.hidden {
+    display: none;
+}
+
 .dpad-middle {
     display: flex;
     gap: 5px;
@@ -741,6 +745,50 @@ body.light-mode .settings-btn .material-symbols-outlined {
 .dpad-btn.dpad-active {
     transform: scale(0.95);
     box-shadow: 0 2px 8px rgba(102, 126, 234, 0.6);
+    background: linear-gradient(135deg, #5568d3 0%, #653a8b 100%);
+}
+
+/* Joystick Controls */
+.joystick-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}
+
+.joystick-container.hidden {
+    display: none;
+}
+
+.joystick-base {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    background: rgba(50, 40, 70, 0.5);
+    border-radius: 50%;
+    border: 3px solid rgba(167, 139, 250, 0.3);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.3);
+}
+
+.joystick-stick {
+    position: absolute;
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 50%;
+    cursor: pointer;
+    transition: all 0.1s ease;
+    box-shadow: 0 4px 15px rgba(102, 126, 234, 0.5);
+    touch-action: none;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.joystick-stick:active {
+    box-shadow: 0 2px 10px rgba(102, 126, 234, 0.7);
     background: linear-gradient(135deg, #5568d3 0%, #653a8b 100%);
 }
 

--- a/style.css
+++ b/style.css
@@ -5,20 +5,19 @@
 }
 
 html {
-    overflow: hidden;
-    height: 100%;
+    overflow: auto;
+    min-height: 100%;
 }
 
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background: linear-gradient(135deg, #1a0b2e 0%, #2d1b4e 100%);
-    height: 100%;
+    min-height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     padding: 10px;
-    overflow: hidden;
-    position: fixed;
+    overflow: auto;
     width: 100%;
 }
 
@@ -813,8 +812,8 @@ body.mobile-mode .controls-panel {
 
 body.mobile-mode .container {
     padding: 10px;
-    max-height: 100vh;
-    overflow-y: auto;
+    max-height: none;
+    overflow-y: visible;
 }
 
 body.mobile-mode .game-header {


### PR DESCRIPTION
## Summary
- Add joystick control option for mobile and tablet modes
- Add swipe-to-turn functionality for touch devices
- Add "Touch Control Type" setting with D-Pad, Joystick, and Swipe options
- Fix mobile viewport cutoff issues at top and bottom of screen
- Improve mobile scrolling behavior
- Control type preference persists via localStorage

## Commits Included
- v5.5.0: Add joystick and swipe controls for mobile/tablet
- v5.5.1: Fix mobile viewport cutoff issues

## Test plan
- [x] D-pad controls work on mobile/tablet
- [x] Joystick controls work without input delay
- [x] Swipe detection works on canvas
- [x] Control type selector switches between all three modes
- [x] Mobile viewport shows full content without cutoff
- [x] Settings persist across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)